### PR TITLE
Add some recommended compiler optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ crate-type = ["cdylib"]
 zed_extension_api = "0.5.0"
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_path_to_error = "0.1"
+
+[profile.release]
+codegen-units = 1 # Allows LLVM to perform better optimization.
+lto = true # Enables link-time-optimizations.
+opt-level = "s" # Prioritizes small binary size. Use `3` if you prefer speed.
+strip = true # Ensures debug symbols are removed.
+


### PR DESCRIPTION
See
[discussion](https://github.com/zed-industries/zed/discussions/21450#discussioncomment-14298679).
You may consider adding these Cargo configurations in order to reduce
the WASM bundle size as well as potential performance benefits.
