### PR TITLE
Bump extension API, remove windows path workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ path = "src/luau.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.5.0"
+zed_extension_api = "0.7.0"
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_path_to_error = "0.1"

--- a/src/luau.rs
+++ b/src/luau.rs
@@ -401,17 +401,7 @@ impl zed::Extension for LuauExtension {
             self.language_server_binary_path(language_server_id, worktree, &settings)?;
 
         let current_dir = std::env::current_dir().unwrap();
-        let current_dir_str = 'outer: {
-            let (platform, _) = zed::current_platform();
-            if platform == zed::Os::Windows {
-                // Remove the '/' at the beginning of the path, as Windows paths don't have it.
-                // (Since we're in WASM, paths always begin with a '/'.)
-                if let Ok(path) = current_dir.strip_prefix("/") {
-                    break 'outer path.display();
-                }
-            }
-            current_dir.display()
-        };
+        let current_dir_str = current_dir.display();
 
         fn is_path_absolute(path: &str) -> bool {
             let (platform, _) = zed::current_platform();


### PR DESCRIPTION
⚠️ Don't merge until Zed 0.205.x is on stable ⚠️

See https://github.com/zed-industries/zed/pull/37811

This PR bumps the zed extension API to the latest version, which removes the need to work around a bug where current_dir() returned an invalid path on windows.

I believe that a custom `fn is_path_absolute(...)` is still required though.