### PR TITLE
Make luau-lsp.types.definitionFiles and definitions interchangeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed endpoint for all requests except luau-lsp download, making GitHub rate limits less likely
   and easier to work around (just use a local binary).
+  
+# Fixed
+
+- Fixed behavioral difference between `luau-lsp.types.definitionFiles` and `definitions`. They can
+  now be used interchangeably.
 
 ## [0.3.3] - 2025-10-16
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,48 @@
+use zed_extension_api::serde_json::{Map, Value, map::Entry};
+
+pub fn get_or_insert_object<'a>(
+    map: &'a mut Map<String, Value>,
+    key: &str,
+) -> &'a mut Map<String, Value> {
+    match map.entry(key.to_string()) {
+        Entry::Vacant(e) => {
+            if let Value::Object(o) = e.insert(Value::Object(Map::new())) {
+                o
+            } else {
+                unreachable!()
+            }
+        }
+        Entry::Occupied(mut e) => {
+            if !e.get().is_object() {
+                e.insert(Value::Object(Map::new()));
+            }
+            if let Value::Object(o) = e.into_mut() {
+                o
+            } else {
+                unreachable!()
+            }
+        }
+    }
+}
+
+pub fn get_or_insert_array<'a>(map: &'a mut Map<String, Value>, key: &str) -> &'a mut Vec<Value> {
+    match map.entry(key.to_string()) {
+        Entry::Vacant(e) => {
+            if let Value::Array(o) = e.insert(Value::Array(Vec::new())) {
+                o
+            } else {
+                unreachable!()
+            }
+        }
+        Entry::Occupied(mut e) => {
+            if !e.get().is_array() {
+                e.insert(Value::Array(Vec::new()));
+            }
+            if let Value::Array(o) = e.into_mut() {
+                o
+            } else {
+                unreachable!()
+            }
+        }
+    }
+}


### PR DESCRIPTION
These accidentally behaved differently. See
https://github.com/4teapo/zed-luau/issues/22