### PR TITLE
Fix luau-lsp settings broken with ext settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `luau-lsp` settings not working when `ext` settings exist.
+
 ## [0.3.4] - 2025-12-29
 
 ### Added

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,4 +1,5 @@
-use zed_extension_api::serde_json::{Map, Value, map::Entry};
+use zed::serde_json::{Map, Value, map::Entry};
+use zed_extension_api::{self as zed};
 
 pub fn get_or_insert_object<'a>(
     map: &'a mut Map<String, Value>,


### PR DESCRIPTION
Having ext in your settings would cause luau-lsp settings to not be read at all.