### PR TITLE
Add const support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support const support in syntax highlighting & others
+
 ## [0.3.7] - 2026-03-01
 
 ### Fixed

--- a/extension.toml
+++ b/extension.toml
@@ -12,4 +12,4 @@ language = "Luau"
 
 [grammars.luau]
 repository = "https://github.com/4teapo/tree-sitter-luau"
-commit = "1d25ccb7b2afb85fc0523c4bca3331ad52c55106"
+commit = "9ce0c38890fe5cbdf2f6e056acb0015888af958f"

--- a/languages/luau/highlights.scm
+++ b/languages/luau/highlights.scm
@@ -2,6 +2,7 @@
 
 [
   "local"
+  "const"
   "while"
   "repeat"
   "until"
@@ -226,6 +227,9 @@
   method: (field_identifier) @function)
 
 (local_function_declaration
+  name: (identifier) @function)
+
+(const_function_declaration
   name: (identifier) @function)
 
 (declare_global_function_declaration

--- a/languages/luau/indents.scm
+++ b/languages/luau/indents.scm
@@ -5,6 +5,7 @@
 (repeat_statement "until" @end) @indent
 (function_declaration "end" @end) @indent
 (local_function_declaration "end" @end) @indent
+(const_function_declaration "end" @end) @indent
 (type_function_declaration "end" @end) @indent
 (function_definition "end" @end) @indent
 

--- a/languages/luau/outline.scm
+++ b/languages/luau/outline.scm
@@ -7,6 +7,13 @@
       name: (identifier) @name
       (#match? @name "^[A-Z][A-Z][A-Z_0-9]*$")) @item))
 
+(const_variable_declaration
+  "const" @context
+  (binding_list
+    (binding
+      name: (identifier) @name
+      (#match? @name "^[A-Z][A-Z][A-Z_0-9]*$")) @item))
+
 (type_alias_declaration
   "export"? @context
   "type" @context
@@ -44,6 +51,14 @@
 
 (local_function_declaration
   "local" @context
+  "function" @context
+  name: (_) @name
+  (parameters
+    "(" @context
+    ")" @context)) @item
+
+(const_function_declaration
+  "const" @context
   "function" @context
   name: (_) @name
   (parameters

--- a/languages/luau/textobjects.scm
+++ b/languages/luau/textobjects.scm
@@ -7,6 +7,9 @@
 (local_function_declaration
   body: (_)* @function.inside) @function.around
 
+(const_function_declaration
+  body: (_)* @function.inside) @function.around
+
 (type_alias_declaration
   type: (_)* @class.inside) @class.around
 


### PR DESCRIPTION
Adds const support in syntax highlighting, indentation, project outline, and text objects

Closes https://github.com/4teapo/zed-luau/issues/40